### PR TITLE
Chore: Add NPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 .DS_Store
+coverage
+npm

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "test": "deno test --coverage=coverage",
     "lcov": "deno coverage coverage --lcov --output=coverage/report.lcov",
     "cover": "deno task clean && deno task test && deno task lcov && genhtml -o coverage/html coverage/report.lcov",
-    "build": "deno run -A scripts/build_npm.ts",
+    "build": "deno run -A scripts/build_npm.ts --cp=LICENSE,README.md",
     "publish": "cd ./npm && npm publish",
     "clean": "rm -rf ./npm ./coverage"
   }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,10 @@
+{
+  "tasks": {
+    "test": "deno test --coverage=coverage",
+    "lcov": "deno coverage coverage --lcov --output=coverage/report.lcov",
+    "cover": "deno task clean && deno task test && deno task lcov && genhtml -o coverage/html coverage/report.lcov",
+    "build": "deno run -A scripts/build_npm.ts",
+    "publish": "cd ./npm && npm publish",
+    "clean": "rm -rf ./npm ./coverage"
+  }
+}

--- a/scripts/build_npm.json
+++ b/scripts/build_npm.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "rust-optionals",
+  "version": "2.0.2",
+  "description": "Rust-like error handling and options for TypeScript, Node, and Deno!",
+  "keywords": [
+    "rust",
+    "some",
+    "none",
+    "option",
+    "result",
+    "ok",
+    "err",
+    "optionals",
+    "error"
+  ],
+  "homepage": "https://github.com/OliverBrotchie/optionals#readme",
+  "bugs": "https://github.com/OliverBrotchie/optionals/issues",
+  "license": "MIT",
+  "contributors": [
+    "Oliver Brotchie <oliver@unazoomer.net>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OliverBrotchie/optionals.git"
+  }
+}

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -49,7 +49,9 @@ const args = parse(Deno.args, {
     "prepatch",
     "prerelease",
   ],
+  string: ['cp'],
   default: {
+    cp: '',
     major: false,
     minor: false,
     patch: false,
@@ -73,8 +75,9 @@ await build({
 });
 
 // post build steps
-await Deno.copyFile("LICENSE", "npm/LICENSE");
-await Deno.copyFile("README.md", "npm/README.md");
+for (const filepath of args.cp.split(/,/g)) {
+  await Deno.copyFile(filepath, `npm/${filepath}`);
+}
 
 if (packageJSON.version === version) {
   console.log(

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -73,7 +73,7 @@ await build({
 });
 
 // post build steps
-await Deno.copyFile("LICENSE.md", "npm/LICENSE.md");
+await Deno.copyFile("LICENSE", "npm/LICENSE");
 await Deno.copyFile("README.md", "npm/README.md");
 
 if (packageJSON.version === version) {

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -6,7 +6,7 @@ import { basename } from "https://deno.land/std@0.160.0/path/mod.ts";
 import {
   inc as increment,
   ReleaseType,
-} from "https://deno.land/x/semver@v1.4.1/mod.ts";
+} from "https://deno.land/std@0.160.0/semver/mod.ts";
 import {
   build,
   BuildOptions,

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -62,7 +62,7 @@ const args = parse(Deno.args, {
 packageJSON.version = versionHandler(version, args);
 
 await build({
-  entryPoints: ["./mod.ts", "./polyfill.ts"],
+  entryPoints: ["./mod.ts"],
   outDir: "./npm",
   shims: {
     deno: true,

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,0 +1,88 @@
+/*
+ * Contributed 2022 by Aaron Huggins under the MIT license.
+ */
+import { parse } from "https://deno.land/std@0.160.0/flags/mod.ts";
+import { basename } from "https://deno.land/std@0.160.0/path/mod.ts";
+import { inc as increment } from "https://deno.land/x/semver@v1.4.1/mod.ts";
+import {
+  build,
+  BuildOptions,
+  emptyDir,
+} from "https://deno.land/x/dnt@0.31.0/mod.ts";
+
+await emptyDir("./npm");
+
+function versionHandler(current: string, inputs: typeof args): string {
+  switch (true) {
+    case inputs.major:
+      return increment(current, "major") ?? current;
+    case inputs.minor:
+      return increment(current, "minor") ?? current;
+    case inputs.patch:
+      return increment(current, "patch") ?? current;
+    case inputs.premajor:
+      return increment(current, "premajor") ?? current;
+    case inputs.preminor:
+      return increment(current, "preminor") ?? current;
+    case inputs.prepatch:
+      return increment(current, "prepatch") ?? current;
+    case inputs.prerelease:
+      return increment(current, "prerelease") ?? current;
+  }
+
+  return current;
+}
+
+const scriptName = basename(import.meta.url, ".ts");
+const logTag = `[${scriptName}]`;
+const packageFile = `./scripts/${scriptName}.json`;
+const packageText = await Deno.readTextFile(packageFile);
+const packageJSON = <BuildOptions["package"]> JSON.parse(packageText);
+const { version } = packageJSON;
+const args = parse(Deno.args, {
+  boolean: [
+    "major",
+    "minor",
+    "patch",
+    "premajor",
+    "preminor",
+    "prepatch",
+    "prerelease",
+  ],
+  default: {
+    major: false,
+    minor: false,
+    patch: false,
+    premajor: false,
+    preminor: false,
+    prepatch: false,
+    prerelease: false,
+  },
+});
+packageJSON.version = versionHandler(version, args);
+
+await build({
+  entryPoints: ["./mod.ts", "./polyfill.ts"],
+  outDir: "./npm",
+  shims: {
+    deno: true,
+  },
+  package: {
+    ...packageJSON,
+  },
+});
+
+// post build steps
+await Deno.copyFile("LICENSE.md", "npm/LICENSE.md");
+await Deno.copyFile("README.md", "npm/README.md");
+
+if (packageJSON.version === version) {
+  console.log(
+    `${logTag} Version did not change; nothing to deploy. ${packageJSON.name} v${version}`,
+  );
+} else {
+  await Deno.writeTextFile(packageFile, JSON.stringify(packageJSON, null, 2));
+  console.log(
+    `${logTag} ${packageJSON.name} v${packageJSON.version} ready to deploy!`,
+  );
+}


### PR DESCRIPTION
- Supports transpiling the Deno src to a node.js-compatible module, with types and both CommonJS and ESM exports.
- Closes #3 once merged and npm module is published.
- Issue `deno task build --release=major|minor|patch|premajor|preminor|prepatch|prerelease` to bump the generated NPM package semantic version
- Then commit the updated `./scripts/build_npm.ts` file and tag the repo