### PR TITLE
feat: convenience helpers and improved spec compliance

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -45,7 +45,7 @@ export class Option<T> {
    * Iterator support for Option.
    */
   *[Symbol.iterator]() {
-    yield this.val;
+    if (this.isSome()) yield this.val;
   }
 
   /**

--- a/src/option.ts
+++ b/src/option.ts
@@ -239,10 +239,26 @@ export class Option<T> {
  * }
  *
  * ```
+ *
+ * @example
+ * ```ts
+ * const foo = Some("Value");
+ *
+ * if (foo instanceof Some) {
+ *  // Do something
+ * }
+ * ```
  */
-export function Some<T>(input: Exclude<T, typeof none>) {
+export function Some<T>(input: Exclude<T, typeof none>): Option<T> {
   return new Option<T>(input as T);
 }
+
+Object.defineProperty(Some, Symbol.hasInstance, {
+  value: <T>(instance: Option<T>): boolean => {
+    if (typeof instance !== "object") return false;
+    return instance?.isSome() || false;
+  },
+});
 
 /**
  * Construct the None variant of Option.
@@ -256,7 +272,22 @@ export function Some<T>(input: Exclude<T, typeof none>) {
  *   return Some(left / right);
  * }
  * ```
+ * @example
+ * ```ts
+ * const foo = None();
+ *
+ * if (foo instanceof None) {
+ *  // Do something
+ * }
+ * ```
  */
 export function None<T>(): Option<T> {
   return new Option<T>(none);
 }
+
+Object.defineProperty(None, Symbol.hasInstance, {
+  value: <T>(instance: Option<T>): boolean => {
+    if (typeof instance !== "object") return false;
+    return instance?.isNone() || false;
+  },
+});

--- a/src/option.ts
+++ b/src/option.ts
@@ -43,6 +43,9 @@ export class Option<T> {
 
   /**
    * Iterator support for Option.
+   *
+   * _Note: This method will only yeild if the Option is Some._
+   * @returns {IterableIterator<T>}
    */
   *[Symbol.iterator]() {
     if (this.isSome()) yield this.val;
@@ -50,7 +53,6 @@ export class Option<T> {
 
   /**
    * Returns true if contained value isnt None.
-   *
    * @returns {boolean}
    */
   isSome(): boolean {

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,14 +1,14 @@
 /**
  * The primitive None value.
  *
- * Note: To construct a None variant Option, please use `None()` instead.
+ * _Note: To construct a None variant Option, please use `None()` instead._
  */
 export const none = Symbol("None");
 
 /**
  * A Rust-like Option class.
  *
- * Note: Please use either `Some` or `None` to construct an Option.
+ * _Note: Please use either `Some` or `None` to construct an Option._
  *
  * @example
  * ```
@@ -26,12 +26,26 @@ export class Option<T> {
   /**
    * A constructor for an Option.
    *
-   * Note: Please use either `Some` or `None` to construct Options.
+   * _Note: Please use either `Some` or `None` to construct Options._
    *
    * @param {T | typeof none} input The value to wrap in an Option.
    */
   constructor(input: T | typeof none) {
     this.val = input;
+  }
+
+  /**
+   * Converts Option into a String for display purposes.
+   */
+  get [Symbol.toStringTag]() {
+    return `Result`;
+  }
+
+  /**
+   * Iterator support for Option.
+   */
+  *[Symbol.iterator]() {
+    yield this.val;
   }
 
   /**
@@ -154,7 +168,7 @@ export class Option<T> {
   /**
    * Returns contained value for use in matching.
    *
-   * Note: Please only use this to match against in `if` or `swtich` statments.
+   * _Note: Please only use this to match against in `if` or `swtich` statments._
    *
    * @returns {T | typeof none}
    * @example
@@ -182,10 +196,27 @@ export class Option<T> {
    * Run a closure in a `try`/`catch` and convert it into an Option.
    * If the function throws an Error, an Option containing None will be reutrned.
    *
+   * _Note: Please use `fromAsync` to capture the result of asynchronous closures._
+   * @param {Function} fn The closure to run.
+   * @returns {Option<T>} The result of the closure.
+   */
+  static from<T>(fn: () => T): Option<T> {
+    try {
+      return new Option<T>(fn());
+    } catch (_) {
+      return new Option<T>(none);
+    }
+  }
+
+  /**
+   * Run an asynchronous closure in a `try`/`catch` and convert it into an Option.
+   * If the function throws an Error, an Option containing None will be reutrned.
+   *
+   * _Note: Please use `from` to capture the result of synchronous closures._
    * @param {Function} fn The closure to run.
    * @returns {Promise<Option<T>>} The result of the closure.
    */
-  static async from<T>(fn: (() => T) | (() => Promise<T>)): Promise<Option<T>> {
+  static async fromAsync<T>(fn: () => Promise<T>): Promise<Option<T>> {
     try {
       return new Option<T>(await fn());
     } catch (_) {

--- a/src/option.ts
+++ b/src/option.ts
@@ -38,7 +38,7 @@ export class Option<T> {
    * Converts Option into a String for display purposes.
    */
   get [Symbol.toStringTag]() {
-    return `Result`;
+    return `Option`;
   }
 
   /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,6 +1,8 @@
 // deno-lint-ignore-file no-prototype-builtins
 /* eslint-disable no-prototype-builtins */
 
+import { None, Option, Some } from "./option.ts";
+
 /**
  * A Rust-like Result class.
  *
@@ -231,6 +233,24 @@ export class Result<T, E extends Error> {
   }
 
   /**
+   * Converts from `Result<T, E>` to `Option<T>`.
+   *
+   * @returns {Option<T>}
+   *
+   * @example
+   * ```ts
+   * const option = Err("Some Error").ok(); // => None()
+   * ```
+   */
+  ok(): Option<T> {
+    if (this.isOk()) {
+      return Some(this.val as T);
+    }
+
+    return None();
+  }
+
+  /**
    * Returns contained value for use in matching.
    *
    * _Note: Please only use this to match against in `if` or `swtich` statments._
@@ -352,7 +372,7 @@ export class Result<T, E extends Error> {
  * }
  * ```
  */
-export function Ok<T, E extends Error>(input?: Exclude<T, E>) {
+export function Ok<T, E extends Error>(input?: T) {
   return new Result<T, E>(input as T);
 }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -39,6 +39,9 @@ export class Result<T, E extends Error> {
 
   /**
    * Iterator support for Result.
+   *
+   * _Note: This method will only yeild if the Result is Ok._
+   * @returns {IterableIterator<T>}
    */
   *[Symbol.iterator]() {
     if (this.isOk()) yield this.val;

--- a/src/result.ts
+++ b/src/result.ts
@@ -41,7 +41,7 @@ export class Result<T, E extends Error> {
    * Iterator support for Result.
    */
   *[Symbol.iterator]() {
-    yield this.val;
+    if (this.isOk()) yield this.val;
   }
 
   /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -339,10 +339,26 @@ export class Result<T, E extends Error> {
  * }
  *
  * ```
+ *
+ * @example
+ * ```ts
+ * const foo = Ok("Foo!");
+ *
+ * if (foo instanceof Ok) {
+ *  // Do something
+ * }
+ * ```
  */
 export function Ok<T, E extends Error>(input?: Exclude<T, E>) {
   return new Result<T, E>(input as T);
 }
+
+Object.defineProperty(Ok, Symbol.hasInstance, {
+  value: <T, E extends Error>(instance: Result<T, E>): boolean => {
+    if (typeof instance !== "object") return false;
+    return instance?.isOk() || false;
+  },
+});
 
 /**
  * Return a error result.
@@ -358,6 +374,15 @@ export function Ok<T, E extends Error>(input?: Exclude<T, E>) {
  * }
  *
  * ```
+ *
+ * @example
+ * ```ts
+ * const foo = Err(new Error("Foo!"));
+ *
+ * if (foo instanceof Err) {
+ *  // Do something
+ * }
+ * ```
  */
 export function Err<T, E extends Error>(input: E | string): Result<T, E> {
   if (typeof input === "string") {
@@ -365,3 +390,10 @@ export function Err<T, E extends Error>(input: E | string): Result<T, E> {
   }
   return new Result<T, E>(input);
 }
+
+Object.defineProperty(Err, Symbol.hasInstance, {
+  value: <T, E extends Error>(instance: Result<T, E>): boolean => {
+    if (typeof instance !== "object") return false;
+    return instance?.isErr() || false;
+  },
+});

--- a/src/tests/option.test.ts
+++ b/src/tests/option.test.ts
@@ -24,8 +24,15 @@ Deno.test("Option", async (t) => {
     assertEquals(new Option("Some")[Symbol.toStringTag], "Option");
   });
 
-  await t.step("Symbol.iterator - Should return correct value.", () => {
-    assertEquals([...new Option("Ok")], ["Ok"]);
+  await t.step(
+    "Symbol.iterator - Should return an array with one element.",
+    () => {
+      assertEquals([...new Option("Ok")], ["Ok"]);
+    }
+  );
+
+  await t.step("Symbol.iterator None - Should return an empty array.", () => {
+    assertEquals([...new Option(none)], []);
   });
 
   await t.step("expect - Should get contained value.", () => {

--- a/src/tests/option.test.ts
+++ b/src/tests/option.test.ts
@@ -14,7 +14,7 @@ Deno.test("Option", async (t) => {
     assert(new Option(symbol).isSome());
   });
 
-  await t.step("isErr - Should correctly identify a None value.", () => {
+  await t.step("isNone - Should correctly identify a None value.", () => {
     assert(!new Option("Some").isNone());
     assert(new Option(none).isNone());
     assert(!new Option(symbol).isNone());
@@ -126,9 +126,19 @@ Deno.test("Result - Supporting Function Tests", async (t) => {
     assertEquals(res.peek(), "Test");
   });
 
+  await t.step("Some instanceof - Should return true.", () => {
+    const res = Some("Test");
+    assert(res instanceof Some);
+  });
+
   await t.step("None - Should return None result.", () => {
     const res = None();
     assertEquals(res.isNone(), true);
+  });
+
+  await t.step("None instanceof - Should return true.", () => {
+    const res = None();
+    assert(res instanceof None);
   });
 
   await t.step("from - Should return Ok result.", () => {

--- a/src/tests/option.test.ts
+++ b/src/tests/option.test.ts
@@ -20,6 +20,14 @@ Deno.test("Option", async (t) => {
     assert(!new Option(symbol).isNone());
   });
 
+  await t.step("Symbol.toStringTag - Should return correct value.", () => {
+    assertEquals(new Option("Some")[Symbol.toStringTag], "Option");
+  });
+
+  await t.step("Symbol.iterator - Should return correct value.", () => {
+    assertEquals([...new Option("Ok")], ["Ok"]);
+  });
+
   await t.step("expect - Should get contained value.", () => {
     const res = new Option("Some").expect("Test");
     assertEquals(res, "Some");

--- a/src/tests/option.test.ts
+++ b/src/tests/option.test.ts
@@ -124,6 +124,18 @@ Deno.test("Option", async (t) => {
     const res = new Option<string>(none).or(new Option("Ok"));
     assertEquals(res.peek(), "Ok");
   });
+
+  await t.step("okOr - Should convert Some to Ok.", () => {
+    const res = new Option("Ok").okOr("Test");
+    assertEquals(res.unwrap(), "Ok");
+    assertEquals(res.isOk(), true);
+  });
+
+  await t.step("okOr None - Should convert None to Err.", () => {
+    const res = new Option<string>(none).okOr("Err");
+    assertEquals(res.unwrapErr(), new Error("Err"));
+    assertEquals(res.isErr(), true);
+  });
 });
 
 Deno.test("Result - Supporting Function Tests", async (t) => {
@@ -154,9 +166,16 @@ Deno.test("Result - Supporting Function Tests", async (t) => {
     assertEquals(res.peek(), "Test");
   });
 
-  await t.step("from Error - Should return None result.", () => {
+  await t.step("from Null - Should return None result.", () => {
     const res = Option.from(() => {
-      throw new Error("Test");
+      return null;
+    });
+    assert(res.isNone());
+  });
+
+  await t.step("from Undefined - Should return None result.", () => {
+    const res = Option.from(() => {
+      return undefined;
     });
     assert(res.isNone());
   });
@@ -169,9 +188,14 @@ Deno.test("Result - Supporting Function Tests", async (t) => {
     assertEquals(res.peek(), "Test");
   });
 
-  await t.step("fromAsync Error - Should return None result.", async () => {
+  await t.step("fromAsync Null - Should return None result.", async () => {
+    const res = await Option.fromAsync(async () => await Promise.resolve(null));
+    assert(res.isNone());
+  });
+
+  await t.step("fromAsync Undefined - Should return None result.", async () => {
     const res = await Option.fromAsync(
-      async () => await Promise.reject(new Error("Test"))
+      async () => await Promise.resolve(undefined)
     );
     assert(res.isNone());
   });

--- a/src/tests/option.test.ts
+++ b/src/tests/option.test.ts
@@ -123,16 +123,31 @@ Deno.test("Result - Supporting Function Tests", async (t) => {
     assertEquals(res.isNone(), true);
   });
 
-  await t.step("from - Should return Ok result.", async () => {
-    const res = await Option.from(() => "Test");
+  await t.step("from - Should return Ok result.", () => {
+    const res = Option.from(() => "Test");
     assert(res.isSome());
     assertEquals(res.peek(), "Test");
   });
 
-  await t.step("from Error - Should return None result.", async () => {
-    const res = await Option.from(() => {
+  await t.step("from Error - Should return None result.", () => {
+    const res = Option.from(() => {
       throw new Error("Test");
     });
+    assert(res.isNone());
+  });
+
+  await t.step("fromAsync - Should return Ok result.", async () => {
+    const res = await Option.fromAsync(
+      async () => await Promise.resolve("Test")
+    );
+    assert(res.isSome());
+    assertEquals(res.peek(), "Test");
+  });
+
+  await t.step("fromAsync Error - Should return None result.", async () => {
+    const res = await Option.fromAsync(
+      async () => await Promise.reject(new Error("Test"))
+    );
     assert(res.isNone());
   });
 });

--- a/src/tests/result.test.ts
+++ b/src/tests/result.test.ts
@@ -210,18 +210,34 @@ Deno.test("Result - Supporting Function Tests", async (t) => {
     assertEquals(res.unwrapErr().message, "Test");
   });
 
-  await t.step("from - Should return Ok result.", async () => {
-    const res = await Result.from(() => "Test");
+  await t.step("from - Should return Ok result.", () => {
+    const res = Result.from(() => "Test");
     assert(res.isOk());
     assertEquals(res.peek(), "Test");
   });
 
-  await t.step("from Error - Should return Err result.", async () => {
-    const res = await Result.from(() => {
+  await t.step("from Error - Should return Err result.", () => {
+    const res = Result.from(() => {
       throw new Error("Test");
     });
     assert(res.isErr());
     assertEquals(res.peek().message, "Test");
+  });
+
+  await t.step("fromAsync - Should return Ok result.", async () => {
+    const res = await Result.fromAsync(
+      async () => await Promise.resolve("Test")
+    );
+    assert(res.isOk());
+    assertEquals(res.peek(), "Test");
+  });
+
+  await t.step("fromAsync Error - Should return Err result.", async () => {
+    const res = await Result.from(
+      async () => await Promise.reject(new Error("Test"))
+    );
+    assert(res.isErr());
+    assertEquals((res.peek() as Error).message, "Test");
   });
 
   await t.step(

--- a/src/tests/result.test.ts
+++ b/src/tests/result.test.ts
@@ -40,6 +40,14 @@ Deno.test("Result", async (t) => {
     }
   );
 
+  await t.step("Symbol.toStringTag - Should return correct value.", () => {
+    assertEquals(new Result("Ok")[Symbol.toStringTag], "Result");
+  });
+
+  await t.step("Symbol.iterator - Should return correct value.", () => {
+    assertEquals([...new Result("Ok")], ["Ok"]);
+  });
+
   await t.step("expect - Should get contained value.", () => {
     const res = new Result("Ok").expect("Test");
     assertEquals(res, "Ok");
@@ -52,6 +60,24 @@ Deno.test("Result", async (t) => {
         new Result(new Error("Test")).expect("Alternative");
       } catch (e) {
         assertEquals(e, new Error("Alternative"));
+        return;
+      }
+      fail("Method did not throw.");
+    }
+  );
+
+  await t.step("expectErr - Should get contained Error value.", () => {
+    const res = new Result(new Error("Test")).expectErr("Alternative");
+    assertEquals(res, new Error("Test"));
+  });
+
+  await t.step(
+    "expectErr Ok - Should throw an Error with a message if Result contains Ok.",
+    () => {
+      try {
+        new Result("Ok").expectErr("Test");
+      } catch (e) {
+        assertEquals(e, new Error("Test"));
         return;
       }
       fail("Method did not throw.");
@@ -233,7 +259,7 @@ Deno.test("Result - Supporting Function Tests", async (t) => {
   });
 
   await t.step("fromAsync Error - Should return Err result.", async () => {
-    const res = await Result.from(
+    const res = await Result.fromAsync(
       async () => await Promise.reject(new Error("Test"))
     );
     assert(res.isErr());

--- a/src/tests/result.test.ts
+++ b/src/tests/result.test.ts
@@ -44,8 +44,15 @@ Deno.test("Result", async (t) => {
     assertEquals(new Result("Ok")[Symbol.toStringTag], "Result");
   });
 
-  await t.step("Symbol.iterator - Should return correct value.", () => {
-    assertEquals([...new Result("Ok")], ["Ok"]);
+  await t.step(
+    "Symbol.iterator - Should return an array with one element.",
+    () => {
+      assertEquals([...new Result("Ok")], ["Ok"]);
+    }
+  );
+
+  await t.step("Symbol.iterator Err - Should return an empty array.", () => {
+    assertEquals([...new Result(new Error("Test"))], []);
   });
 
   await t.step("expect - Should get contained value.", () => {

--- a/src/tests/result.test.ts
+++ b/src/tests/result.test.ts
@@ -222,6 +222,17 @@ Deno.test("Result", async (t) => {
   await t.step("throw Ok - Should not throw an Error.", () => {
     new Result("Ok").throw();
   });
+
+  await t.step("ok - Should convert Ok to Some.", () => {
+    const res = new Result("Ok").ok();
+    assertEquals(res.unwrap(), "Ok");
+    assertEquals(res.isSome(), true);
+  });
+
+  await t.step("ok Error - Should convert Err to None.", () => {
+    const res = new Result<string, Error>(new Error("Test")).ok();
+    assert(res.isNone());
+  });
 });
 
 Deno.test("Result - Supporting Function Tests", async (t) => {

--- a/src/tests/result.test.ts
+++ b/src/tests/result.test.ts
@@ -224,6 +224,11 @@ Deno.test("Result - Supporting Function Tests", async (t) => {
     assertEquals(res.peek(), "Test");
   });
 
+  await t.step("Ok instanceof - Should return true.", () => {
+    const res = Ok("Test");
+    assertEquals(res instanceof Ok, true);
+  });
+
   await t.step("Err - Should return Error result.", () => {
     const res = Err(new Error("Test"));
     assertEquals(res.isErr(), true);
@@ -234,6 +239,11 @@ Deno.test("Result - Supporting Function Tests", async (t) => {
     const res = Err("Test");
     assertEquals(res.isErr(), true);
     assertEquals(res.unwrapErr().message, "Test");
+  });
+
+  await t.step("Err instanceof - Should return true.", () => {
+    const res = Err(new Error("Test"));
+    assertEquals(res instanceof Err, true);
   });
 
   await t.step("from - Should return Ok result.", () => {


### PR DESCRIPTION
Thanks to @aaronhuggins for the suggestions, please see #6 for more information!

### Additions

*Convenience helpers*
- [x] `from` -  **Breaking Changes**, diverges to `from` (synchronous) and `fromAsync` (asynchronous) to avoid the creation of unnecessary microtasks.
- [x] `Symbol.toStringTag` - useful to quickly and easily distinguish resulting objects.
- [x] `Symbol.hasInstance` - `Err`, `Ok`, `Some`, `None`; example `foo instanceof Err`.

*Spec compliance*
- [x] `Iterator` support - Provides iterator deserialization by yielding the internal value.
- [x] `Result.expectErr` - An extra method to expect an error result.


Closes #6